### PR TITLE
Fix `onLivingEntityTick` error on dedicated server

### DIFF
--- a/src/main/java/uwu/lopyluna/unify/event/UnifyEvent.java
+++ b/src/main/java/uwu/lopyluna/unify/event/UnifyEvent.java
@@ -18,6 +18,7 @@ import net.minecraftforge.event.AddPackFindersEvent;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.forgespi.language.IModFileInfo;
@@ -103,7 +104,7 @@ public class UnifyEvent {
 
     @SubscribeEvent
     public static void onLivingEntityTick(LivingEvent.LivingTickEvent event) {
-        if (event.getEntity() instanceof Player player && !UnifyMaterialProvider.getEntries().isEmpty() && !(player.containerMenu instanceof CreativeModeInventoryScreen.ItemPickerMenu)) {
+        if (event.getEntity() instanceof Player player && !UnifyMaterialProvider.getEntries().isEmpty() && !DistExecutor.safeRunForDist(() -> () -> player.containerMenu instanceof CreativeModeInventoryScreen.ItemPickerMenu, () -> () -> false)) {
             List<Slot> slots = player.hasContainerOpen() ? player.containerMenu.slots : player.inventoryMenu.slots;
             for (Slot slot : slots) {
                 ItemStack itemStack = slot.getItem();


### PR DESCRIPTION
Resolves #6

The issue was caused by trying to see if a player has the `CreativeModeInventoryScreen.ItemPickerMenu` open on the physical server side. The class doesn't exist on the physical server so loading it throws an error.

My fix was to wrap this check in a `DistExecutor` which does the same check on the client, and always returns false on the server, as we can't have any GUIs open on the server.

I have tested this on a modded server I am hosting for some friends, and have had no issues so far.